### PR TITLE
feat: add multi-server speedtest support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ make clean          # Remove build artifacts
 goreleaser release --snapshot --clean
 
 # Run locally
-./speedtest_exporter -port 9090 -server_id -1 -server_fallback=false
+./speedtest_exporter -port 9090 -server_ids "-1" -server_fallback=false
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Usage of speedtest_exporter
   -port string
         listening port to expose metrics on (default "9090")
   -server_fallback
-        If the serverID given is not available, should we fallback to closest available server
-  -server_id int
-        Speedtest.net server ID to run test against, -1 will pick the closest server to your location (default -1)
+        If a requested server ID is not available, fall back to the closest available server
+  -server_ids string
+        Comma-separated Speedtest.net server IDs to test against, -1 picks the closest server (default "-1")
 
 ```
 

--- a/cmd/speedtest_exporter/main_test.go
+++ b/cmd/speedtest_exporter/main_test.go
@@ -42,6 +42,47 @@ func TestHealthHandler(t *testing.T) {
 	}
 }
 
+func TestParseServerIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []int
+		wantErr bool
+	}{
+		{name: "single ID", input: "12345", want: []int{12345}},
+		{name: "default closest", input: "-1", want: []int{-1}},
+		{name: "multiple IDs", input: "100,200,300", want: []int{100, 200, 300}},
+		{name: "spaces around IDs", input: " 100 , 200 , 300 ", want: []int{100, 200, 300}},
+		{name: "empty string", input: "", wantErr: true},
+		{name: "non-numeric", input: "abc", wantErr: true},
+		{name: "mixed valid and invalid", input: "100,abc", wantErr: true},
+		{name: "trailing comma", input: "100,200,", want: []int{100, 200}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseServerIDs(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: expected %d, got %d", i, tt.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && searchStr(s, substr)
 }


### PR DESCRIPTION
## Summary

- Replace `-server_id` (int) flag with `-server_ids` (comma-separated string) to test multiple servers per scrape
- Servers tested sequentially to avoid bandwidth contention; per-server metrics differentiated by existing labels
- `speedtest_up` = 1 only when all servers succeed; write/shutdown timeouts scale by server count

## Test plan

- [x] All 22 existing + new tests pass with race detector
- [x] `make fmt-check`, `tidy-check`, `build` pass
- [ ] Manual: `./speedtest_exporter -server_ids "-1"` (default closest)
- [ ] Manual: `./speedtest_exporter -server_ids "12345,67890"` (multi-server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)