### PR TITLE
feat: add -max_connections flag to tune speedtest concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A [Speedtest](https://www.speedtest.net) exporter for Prometheus.
 ```bash
 $ ./speedtest_exporter --help
 Usage of speedtest_exporter
+  -max_connections int
+        Maximum concurrent connections for speed tests (0 = auto-detect based on CPU count) (default 0)
   -port string
         listening port to expose metrics on (default "9090")
   -server_fallback
@@ -34,6 +36,8 @@ Usage of speedtest_exporter
         Comma-separated Speedtest.net server IDs to test against, -1 picks the closest server (default "-1")
 
 ```
+
+> **Tip:** If you have a high-bandwidth connection (500 Mbps+) and see lower-than-expected results, try setting `-max_connections 8`. The default (0) uses `runtime.NumCPU()`, which may be too low in Docker containers with limited CPU allocation.
 
 ### Binaries
 

--- a/cmd/speedtest_exporter/main.go
+++ b/cmd/speedtest_exporter/main.go
@@ -99,6 +99,7 @@ func main() {
 	port := flag.String("port", "9090", "listening port to expose metrics on")
 	serverIDsFlag := flag.String("server_ids", "-1", "Comma-separated Speedtest.net server IDs to test against, -1 picks the closest server")
 	serverFallback := flag.Bool("server_fallback", false, "If a requested server ID is not available, fall back to the closest available server")
+	maxConnections := flag.Int("max_connections", 0, "Maximum concurrent connections for speed tests (0 = auto-detect based on CPU count)")
 	flag.Parse()
 
 	serverIDs, err := parseServerIDs(*serverIDsFlag)
@@ -107,7 +108,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	exp := exporter.New(serverIDs, *serverFallback)
+	exp := exporter.New(serverIDs, *serverFallback, *maxConnections)
 
 	http.HandleFunc("/", rootHandler())
 	http.HandleFunc("/health", healthHandler())
@@ -135,7 +136,7 @@ func main() {
 		}
 	}()
 
-	slog.Info("server started", "port", *port, "server_ids", serverIDs)
+	slog.Info("server started", "port", *port, "server_ids", serverIDs, "max_connections", *maxConnections)
 
 	// Wait for shutdown signal.
 	<-ctx.Done()

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -96,12 +96,14 @@ type Exporter struct {
 }
 
 // New returns an initialized Exporter.
-func New(serverIDs []int, serverFallback bool) *Exporter {
+func New(serverIDs []int, serverFallback bool, maxConnections int) *Exporter {
 	return &Exporter{
 		serverIDs:      serverIDs,
 		serverFallback: serverFallback,
-		client:         &defaultClient{inner: speedtest.New()},
-		runner:         &defaultRunner{},
+		client: &defaultClient{inner: speedtest.New(
+			speedtest.WithUserConfig(&speedtest.UserConfig{MaxConnections: maxConnections}),
+		)},
+		runner: &defaultRunner{},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `-max_connections` CLI flag to configure concurrent connections for speed tests
- Passes value through to `speedtest.WithUserConfig()` in the speedtest-go library
- Default (0) preserves existing behavior (`runtime.NumCPU()`), which can be too low in containers
- Documents the flag in README with a tip for high-bandwidth (500 Mbps+) connections

Closes #24

## Test plan

- [x] All 20 existing tests pass (`make test-race`)
- [x] `./speedtest_exporter -help` shows new `-max_connections` flag
- [x] `make fmt-check`, `tidy-check`, `build` all pass
- [ ] CI lint + build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)